### PR TITLE
🎨 [refactor] Simplified use of docker suffixes

### DIFF
--- a/.github/actions/create_docker_image_impl/action.yml
+++ b/.github/actions/create_docker_image_impl/action.yml
@@ -15,12 +15,7 @@ name: "[impl] Create Docker Image"
 description: "Creates a Docker image within the current repository"
 
 inputs:
-  docker_name_suffix:
-    required: false
-    type: string
-    default: ""
-
-  docker_tag_suffix:
+  name_suffix:
     required: false
     type: string
     default: ""
@@ -82,7 +77,7 @@ runs:
       shell: ${{ inputs.shell_name }}
       run: |
         ${{ inputs.source_command }} ${{ inputs.script_prefix }}Activate${{ inputs.script_extension }}
-        python Build.py create_docker_image --name-suffix "${{ inputs.docker_name_suffix }}" --tag-suffix "${{ inputs.docker_tag_suffix }}" --description "${{ inputs.docker_description }}" --bootstrap-args "${{ inputs.bootstrap_args }}" --verbose
+        python Build.py create_docker_image --name-suffix "${{ inputs.name_suffix }}" --description "${{ inputs.docker_description }}" --bootstrap-args "${{ inputs.bootstrap_args }}" --verbose
 
     - name: Get Image Name
       id: image_name
@@ -107,15 +102,15 @@ runs:
             BuildActivities.SaveDockerImage(
                 dm,
                 '${{ steps.image_name.outputs.IMAGE_NAME }}',
-                Path('./${{ steps.image_name.outputs.IMAGE_NAME_NO_TAG }}.tar${{ inputs.compressed_extension }}'),
+                Path('./${{ steps.image_name.outputs.IMAGE_NAME_NO_TAG }}${{ inputs.name_suffix }}.tar${{ inputs.compressed_extension }}'),
             )
         "
 
     - name: Upload Docker Image
       uses: actions/upload-artifact@v4
       with:
-        name: docker_image-${{ inputs.docker_tag_suffix }}.tar${{ inputs.compressed_extension }}
-        path: ${{ steps.image_name.outputs.IMAGE_NAME_NO_TAG }}.tar${{ inputs.compressed_extension }}
+        name: docker_image${{ inputs.name_suffix }}.tar${{ inputs.compressed_extension }}
+        path: ${{ steps.image_name.outputs.IMAGE_NAME_NO_TAG }}${{ inputs.name_suffix }}.tar${{ inputs.compressed_extension }}
 
     - name: Log in to the Container registry
       if: ${{ inputs.push_image_as_package && github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/callable_create_docker_image.yaml
+++ b/.github/workflows/callable_create_docker_image.yaml
@@ -25,13 +25,7 @@ on:
         required: true
         type: string
 
-      docker_name_suffix:
-        # Optional suffix applied to the image name
-        required: false
-        type: string
-        default: ""
-
-      docker_tag_suffix:
+      name_suffix:
         # Optional suffix applied to the image tag
         required: false
         type: string
@@ -85,8 +79,7 @@ jobs:
       - name: Create Docker Image
         uses: davidbrownell/dbrownell_DevTools/.github/actions/create_docker_image_impl@CITemporary # main
         with:
-          docker_name_suffix: ${{ inputs.docker_name_suffix }}
-          docker_tag_suffix: ${{ inputs.docker_tag_suffix }}
+          name_suffix: ${{ inputs.name_suffix }}
           docker_description: ${{ inputs.docker_description }}
           push_image_as_package: ${{ inputs.push_image_as_package }}
           container_registry_password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/standard.yaml
+++ b/.github/workflows/standard.yaml
@@ -146,7 +146,7 @@ jobs:
     with:
       operating_system: ubuntu-latest
       python_version: ${{ matrix.python_version }}
-      docker_tag_suffix: ${{ matrix.python_version }}
+      name_suffix: -${{ matrix.python_version }}
       docker_description: "dbrownell_DevTools - ${{ matrix.python_version }}"
       push_image_as_package: true
 

--- a/src/dbrownell_DevTools/BuildActivities.py
+++ b/src/dbrownell_DevTools/BuildActivities.py
@@ -81,8 +81,7 @@ def CreateDockerImage(
     repo_root: Path,
     create_base_image_func: Optional[CreateBaseImageFunc] = None,
     bootstrap_args: str = "--package",
-    docker_name_suffix: Optional[str] = None,
-    docker_tag_suffix: Optional[str] = None,
+    name_suffix: Optional[str] = None,
     docker_license: Optional[str] = None,  # https://spdx.org/licenses/
     docker_description: Optional[str] = None,
 ) -> Optional[str]:
@@ -119,8 +118,7 @@ def CreateDockerImage(
 
                 with _CreateFinalImage(
                     dm,
-                    docker_name_suffix,
-                    docker_tag_suffix,
+                    name_suffix,
                     last_commit.lower(),
                     docker_license,
                     docker_description,
@@ -454,7 +452,6 @@ def _SaveTemporaryImage(
 def _CreateFinalImage(
     dm: DoneManager,
     name_suffix: Optional[str],
-    tag_suffix: Optional[str],
     commit_hash: str,
     docker_license: Optional[str],
     docker_description: Optional[str],
@@ -463,12 +460,7 @@ def _CreateFinalImage(
 ) -> Generator[str, None, None]:
     repo_name = repo_origin.split("/")[-1]
 
-    image_name = "{}{}:{}{}".format(
-        repo_name,
-        f"-{name_suffix}" if name_suffix else "",
-        commit_hash,
-        f"-{tag_suffix}" if tag_suffix else "",
-    ).lower()
+    image_name = f"{repo_name}:{commit_hash}{name_suffix}".lower()
 
     docker_filename = Path(f"{repo_name}.dockerfile")
 

--- a/src/dbrownell_DevTools/RepoBuildTools/Python.py
+++ b/src/dbrownell_DevTools/RepoBuildTools/Python.py
@@ -433,14 +433,7 @@ def CreateDockerImageFuncFactory(
             Optional[str],
             typer.Option(
                 "--name-suffix",
-                help="Suffix applies to the docker image name.",
-            ),
-        ] = None,
-        tag_suffix: Annotated[
-            Optional[str],
-            typer.Option(
-                "--tag-suffix",
-                help="Suffix applied to the docker image tag.",
+                help="Suffix applies to the docker image tag.",
             ),
         ] = None,
         description: Annotated[
@@ -477,7 +470,6 @@ def CreateDockerImageFuncFactory(
                 create_base_image_func,
                 final_bootstrap_args,
                 name_suffix,
-                tag_suffix,
                 docker_license,
                 description or default_description,
             )

--- a/tests/BuildActivities_EndToEndTest.py
+++ b/tests/BuildActivities_EndToEndTest.py
@@ -61,7 +61,7 @@ def test_CreateDockerImage():
                 creating_dm,
                 repo_root,
                 bootstrap_args="--package --verbose",
-                docker_name_suffix=unique_id,
+                name_suffix=unique_id,
             )
 
             assert creating_dm.result == 0

--- a/tests/RepoBuildTools/Python_UnitTest.py
+++ b/tests/RepoBuildTools/Python_UnitTest.py
@@ -334,22 +334,19 @@ def test_CreateDockerImage():
             "the_description",
             "--name-suffix",
             "the_name_suffix",
-            "--tag-suffix",
-            "the_tag_suffix",
         ],
         "BuildActivities",
     )
 
     assert result.exit_code == 0
     assert result.stdout == ""
-    assert len(args) == 8
+    assert len(args) == 7
     assert args[1] == Path.cwd()
     assert args[2] is None  # create_base_image_func
     assert args[3] == "--package foo"
     assert args[4] == "the_name_suffix"
-    assert args[5] == "the_tag_suffix"
-    assert args[6] == "MIT"
-    assert args[7] == "the_description"
+    assert args[5] == "MIT"
+    assert args[6] == "the_description"
     assert not kwargs
 
 


### PR DESCRIPTION
Previously, it was possible set a suffix for a docker image's name and a suffix for its tag. Now, there is only one suffix and it is used in a consistent way.