### PR TITLE
✨ [+feature] Support for GitHub organizations

### DIFF
--- a/.github/actions/create_docker_image_impl/action.yml
+++ b/.github/actions/create_docker_image_impl/action.yml
@@ -33,6 +33,10 @@ inputs:
     type: boolean
     default: false
 
+  container_registry_username:
+    required: false
+    type: string
+
   container_registry_password:
     required: false
     type: string
@@ -116,7 +120,7 @@ runs:
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
-        username: ${{ github.actor }}
+        username: ${{ inputs.container_registry_username }}
         password: ${{ inputs.container_registry_password }}
 
     - name: Push Docker Image
@@ -131,11 +135,11 @@ runs:
         from dbrownell_Common.Streams.DoneManager import DoneManager
         from dbrownell_DevTools import BuildActivities
 
-        with DoneManager.Create(sys.stdout, 'Pushing...') as dm:
+        with DoneManager.CreateCommandLine() as dm:
             BuildActivities.PushDockerImage(
                 dm,
                 '${{ steps.image_name.outputs.IMAGE_NAME }}',
                 'ghcr.io',
-                '${{ github.actor }}',
+                '${{ inputs.container_registry_username }}',
             )
         "

--- a/.github/workflows/callable_create_docker_image.yaml
+++ b/.github/workflows/callable_create_docker_image.yaml
@@ -48,6 +48,11 @@ on:
         type: boolean
         default: false
 
+      container_registry_username:
+        required: false
+        type: string
+        default: ""
+
 jobs:
   docker_image:
     name: Execute
@@ -77,11 +82,12 @@ jobs:
           operating_system: ${{ inputs.operating_system }}
 
       - name: Create Docker Image
-        uses: davidbrownell/dbrownell_DevTools/.github/actions/create_docker_image_impl@main
+        uses: davidbrownell/dbrownell_DevTools/.github/actions/create_docker_image_impl@CITemporary # main
         with:
           name_suffix: ${{ inputs.name_suffix }}
           docker_description: ${{ inputs.docker_description }}
           push_image_as_package: ${{ inputs.push_image_as_package }}
+          container_registry_username: ${{ inputs.container_registry_username }}
           container_registry_password: ${{ secrets.GITHUB_TOKEN }}
           bootstrap_args: ${{ inputs.bootstrap_args }}
           operating_system: ${{ inputs.operating_system }}

--- a/.github/workflows/standard.yaml
+++ b/.github/workflows/standard.yaml
@@ -142,13 +142,14 @@ jobs:
 
     name: Create Docker Image
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@main
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CITemporary # main
     with:
       operating_system: ubuntu-latest
       python_version: ${{ matrix.python_version }}
       name_suffix: -${{ matrix.python_version }}
       docker_description: "dbrownell_DevTools - ${{ matrix.python_version }}"
       push_image_as_package: true
+      container_registry_username: ${{ github.actor }}
 
   # ----------------------------------------------------------------------
   publish:


### PR DESCRIPTION
Previously, ${{ github.actor }} was used as the username when authenticating with ghcr.io. However, that value is not defined when running on a repo within an organization. The username must now be passed to the callable workflow.