### PR TITLE
🎨 [refactor] Simplified specification of dynamic README content

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,9 +69,7 @@ dynamic = [
     "version",
 ]
 
-# The README.md file used when generating packages will be dynamically generated based on the content
-# found in README.md.
-readme = "dynamic_README.md"
+readme = "README.md"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
The readme value in pyproject.toml no longer needs a `dynamic_` prefix.