### PR TITLE
🐛 [-bug] Run pytest from the source root (for pyproject.toml access)

### DIFF
--- a/.github/actions/validate_python_impl/action.yml
+++ b/.github/actions/validate_python_impl/action.yml
@@ -73,4 +73,4 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: .coverage.${{ inputs.operating_system }}.${{ inputs.python_version }}
-        path: tests/.coverage.${{ inputs.operating_system }}.${{ inputs.python_version }}
+        path: "**/.coverage.${{ inputs.operating_system }}.${{ inputs.python_version }}"

--- a/Build.py
+++ b/Build.py
@@ -46,14 +46,13 @@ app = typer.Typer(
 # ----------------------------------------------------------------------
 this_dir = PathEx.EnsureDir(Path(__file__).parent)
 src_dir = PathEx.EnsureDir(this_dir / "src" / "dbrownell_DevTools")
-tests_dir = PathEx.EnsureDir(this_dir / "tests")
 
 
 # ----------------------------------------------------------------------
 Black = RepoBuildTools.BlackFuncFactory(this_dir, app)
 Pylint = RepoBuildTools.PylintFuncFactory(src_dir, app)
 Pytest = RepoBuildTools.PytestFuncFactory(
-    tests_dir,
+    this_dir,
     "dbrownell_DevTools",
     app,
     default_min_coverage=60.0,

--- a/src/dbrownell_DevTools/PythonBuildActivities.py
+++ b/src/dbrownell_DevTools/PythonBuildActivities.py
@@ -84,7 +84,7 @@ def Pylint(
 # ----------------------------------------------------------------------
 def Pytest(
     dm: DoneManager,
-    test_root: Path,
+    source_root: Path,
     python_package_name: str,
     min_coverage: Optional[float] = None,
     *,
@@ -111,7 +111,7 @@ def Pytest(
             pytest_dm.result = SubprocessEx.Stream(
                 command_line,
                 stream,
-                cwd=test_root,
+                cwd=source_root,
             )
 
 


### PR DESCRIPTION
Previously, pytest was run from the "tests" directory. But pytest did not read settings from pyproject.toml when run from that directory. With this change, tests are run from the root allowing access to settings in pyproject.toml.

Changes were also made to the CI workflows to upload .coverage files if they were found at the root or in the tests directory.