### PR TITLE
🎨 [refactor] Removed checksum when cogging vscode tests

### DIFF
--- a/src/dbrownell_DevTools/Scripts/Python/VSCodeTests.py
+++ b/src/dbrownell_DevTools/Scripts/Python/VSCodeTests.py
@@ -126,7 +126,6 @@ if os.getenv(IS_COGGING_ENVVAR_NAME, None) is None:
                     result = cogger.main(
                         [
                             "custom_cog",  # Fake script name
-                            "-c",  # Checksum
                             "-e",  # Warn if a file has no cog code in it
                             "-r",  # Replace
                             "--verbosity=0",


### PR DESCRIPTION
The checksum becomes invalid when the generated content changes (for example, when test arguments are added). cog silently fails when the checksum doesn't match.  This change removes the checksum so cog always generates new content (overwriting any custom changes to the generated content).