### PR TITLE
🐛 [-bug] Fixed bug associated with env activation with docker images

### DIFF
--- a/src/dbrownell_DevTools/BuildActivities.py
+++ b/src/dbrownell_DevTools/BuildActivities.py
@@ -393,7 +393,7 @@ def _CreateDockerContainer(
                     cd code
                     ./Bootstrap.sh {bootstrap_args}
 
-                    echo "source /code/Activate.sh" >> /etc/bash.bashrc
+                    echo "source /code/Activate.sh" >> ~/.bash_profile
 
                     . ./Activate.sh
                     pip cache purge


### PR DESCRIPTION
Docker development environment images weren't specifying profile variables in the right file, so the activation activities were only happening in interactive sessions. This fix ensures that the variables are introduced in all sessions.