### PR TITLE
👽️ [external_api_change] Updated twine dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dev = [
 
 package = [
     "build ~= 1.2",
-    "twine ~= 5.1",
+    "twine ~= 6.1",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## :pencil: Description
`python Build.py publish` was failing to publish due to an outdated dependency.

## :gear: Work Item
N/A

## :movie_camera: Demo
N/A